### PR TITLE
JOO-31 feat(swagger) : 스웨거에 배포를 한 날 노출, 스웨거 설정

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -9,7 +9,6 @@ import (
 )
 
 // @title Joosum App
-// @version 230606
 // @description This is API Docs for Joosum App.
 // @termsOfService http://swagger.io/terms/
 // @contact.name Pinkboss

--- a/backend/pkg/routes/swagger_routes.go
+++ b/backend/pkg/routes/swagger_routes.go
@@ -6,13 +6,27 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"joosum-backend/docs"
 	"strings"
+	"time"
 )
 
 // SwaggerRoutes func for describe group of Swagger routes.
 func SwaggerRoutes(router *gin.Engine) {
 	router.Use(getPrefix())
 
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	// 스웨거에 배포를 한 날 (서버를 띄운 날) 이 노출
+	dateServerStarted := time.Now().Format("060102")
+	docs.SwaggerInfo.Version = dateServerStarted
+
+	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler,
+
+		// 스웨거 설정 - https://github.com/swaggo/gin-swagger
+		ginSwagger.DocExpansion("nothing"), // Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing).
+		//ginSwagger.DeepLinking(),                // If set to true, enables deep linking for tags and operations. See the Deep Linking documentation for more information.
+		//ginSwagger.DefaultModelsExpandDepth(), // 	Default expansion depth for models (set to -1 completely hide the models).
+		//ginSwagger.InstanceName(), // The instance name of the swagger document. If multiple different swagger instances should be deployed on one gin router, ensure that each instance has a unique name (use the --instanceName parameter to generate swagger documents with swag init).
+		ginSwagger.PersistAuthorization(true), // 	If set to true, it persists authorization data and it would not be lost on browser close/refresh.
+		//ginSwagger.Oauth2DefaultClientID(),      // If set, it's used to prepopulate the client_id field of the OAuth2 Authorization dialog.
+	))
 }
 
 // Host 에 따라 문서 basePath 설정


### PR DESCRIPTION
1. 스웨거에 배포를 한 날 (서버를 띄운 날) 이 노출되도록 수정
2. 태그의 api 들이 디폴트로 접히도록 설정
3. Authorization 이 브라우저를 닫거나 다시 열어도 유지되도록 설정

<img width="668" alt="image" src="https://github.com/pink-boss/joosum-backend/assets/70655507/f0eb38e0-6780-4596-b2bd-c0748dbc9127">

여기 배포를 한 날짜를 띄우고 싶어서 작업했습니다. (동작은 서버, 컨테이너를 띄운 날로 적용이 돼요) 
스웨거 관련 설정도 추가했어요 
