### PR TITLE
Fix collection init bug

### DIFF
--- a/backend/pkg/db/collection.go
+++ b/backend/pkg/db/collection.go
@@ -63,7 +63,7 @@ func LinkEnsureIndexes(collection *mongo.Collection) error {
 
 func InitLinkCollection(client *mongo.Client, dbName string) {
 	LinkCollection = client.Database(dbName).Collection("links")
-	LinkEnsureIndexes(UserCollection)
+	LinkEnsureIndexes(LinkCollection)
 }
 
 var LinkBookCollection *mongo.Collection


### PR DESCRIPTION
## Summary
- fix incorrect index initialization for LinkCollection

## Testing
- `go vet ./...` *(fails: fetching dependencies forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68442ea2ef28832c8f739f4eaf9e5670