### PR TITLE
Add endpoint to list withdrawn users from inactive collection

### DIFF
--- a/backend/app/user/user_handler.go
+++ b/backend/app/user/user_handler.go
@@ -48,3 +48,22 @@ func (h UserHandler) DeleteUser(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"message": "유저 삭제 성공"})
 }
+
+// GetWithdrawUsers
+// @Tags 유저
+// @Summary 탈퇴한 유저 목록을 조회합니다.
+// @Description
+// @Accept json
+// @Produce json
+// @Success 200 {array} InactiveUser
+// @Failure 500 {object} util.APIError "서버에서 유저 조회 실패"
+// @Router /withdraw-users [get]
+func (h UserHandler) GetWithdrawUsers(c *gin.Context) {
+	users, err := h.userUsecase.GetWithdrawUsers()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "서버에서 유저 조회 실패"})
+		return
+	}
+
+	c.JSON(http.StatusOK, users)
+}

--- a/backend/app/user/user_model.go
+++ b/backend/app/user/user_model.go
@@ -179,3 +179,23 @@ func (*UserModel) CreateInactiveUserByUser(user *User) error {
 	return nil
 
 }
+
+func (*UserModel) FindInactiveUsers() ([]*InactiveUser, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var users []*InactiveUser
+
+	cursor, err := db.InactiveUserCollection.Find(ctx, bson.M{})
+	if err != nil {
+		return nil, err
+	}
+
+	for cursor.Next(ctx) {
+		var user InactiveUser
+		cursor.Decode(&user)
+		users = append(users, &user)
+	}
+
+	return users, nil
+}

--- a/backend/app/user/user_usecase.go
+++ b/backend/app/user/user_usecase.go
@@ -40,6 +40,14 @@ func (u UserUsecase) UpdateUserToInactiveUserByEmail(email string) error {
 	return nil
 }
 
+func (u UserUsecase) GetWithdrawUsers() ([]*InactiveUser, error) {
+	users, err := u.userModel.FindInactiveUsers()
+	if err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
 func (u UserUsecase) GetInactiveUserByEmail(email string) (*InactiveUser, error) {
 	inactiveUser, err := u.userModel.FindInactiveUser(email)
 	if err != nil {

--- a/backend/pkg/routes/private_routes.go
+++ b/backend/pkg/routes/private_routes.go
@@ -30,6 +30,7 @@ func PrivateRoutes(router *gin.Engine) {
 	router.Use(middleware.SetUserData())
 
 	router.GET("/protected", authHandler.Protected)
+	router.GET("/withdraw-users", UserHandler.GetWithdrawUsers)
 
 	pageRouter := router.Group("/pages")
 	{


### PR DESCRIPTION
## Summary
- fetch withdrawn users from `InactiveUser` collection instead of separate table
- drop `WithdrawUserCollection` initialization and related model code
- expose `GET /withdraw-users` returning inactive user data

## Testing
- `go vet ./...` *(fails: modules cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68442ec26228832c8220fde6615f8604