### PR TITLE
최근 사용 태그 우선 정렬 기능 추가

### DIFF
--- a/backend/app/link/link_handler.go
+++ b/backend/app/link/link_handler.go
@@ -1,6 +1,7 @@
 package link
 
 import (
+	"joosum-backend/app/tag"
 	"joosum-backend/app/user"
 	"net/http"
 
@@ -9,6 +10,7 @@ import (
 
 type LinkHandler struct {
 	linkUsecase LinkUsecase
+	tagUsecase  tag.TagUsecase
 }
 
 type CreateLinkReq struct {
@@ -67,6 +69,9 @@ func (h LinkHandler) CreateLink(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+
+	// 최근 사용한 태그 기록
+	_ = h.tagUsecase.UpdateLastUsedTags(userId, req.Tags)
 
 	// 200 OK
 	c.JSON(http.StatusOK, link)

--- a/backend/app/tag/tag_usecase.go
+++ b/backend/app/tag/tag_usecase.go
@@ -17,10 +17,30 @@ func (u TagUsecase) CreateTags(userId string, names []string) (*Tag, error) {
 }
 
 func (u TagUsecase) FindTagsByUserId(userId string) ([]string, error) {
-	tags, err := u.tagModel.FindTagsByUserId(userId)
+	tagData, err := u.tagModel.FindTagByUserId(userId)
 	if err != nil {
 		return nil, err
 	}
+
+	tags := make([]string, 0)
+
+	used := make(map[string]bool)
+	for _, tag := range tagData.LastUsed {
+		for _, name := range tagData.Names {
+			if tag == name && !used[tag] {
+				tags = append(tags, tag)
+				used[tag] = true
+			}
+		}
+	}
+
+	for _, name := range tagData.Names {
+		if !used[name] {
+			tags = append(tags, name)
+			used[name] = true
+		}
+	}
+
 	return tags, nil
 }
 
@@ -36,4 +56,13 @@ func (u TagUsecase) DeleteTag(userId string, tag string) ([]string, error) {
 	}
 
 	return tags, err
+}
+
+// UpdateLastUsedTags는 사용자가 링크를 저장할 때 사용한 태그 순서를 기록합니다.
+func (u TagUsecase) UpdateLastUsedTags(userId string, tags []string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return u.tagModel.UpdateLastUsedTags(userId, tags)
 }


### PR DESCRIPTION
## 요약
- 태그 스키마에 마지막 사용 태그 목록(`last_used`) 필드 추가
- 링크 생성 시 사용한 태그를 저장하도록 수정
- 태그 조회 시 최근 사용한 태그가 먼저 오도록 정렬

## 테스트
- `go test ./...` 실행 시 네트워크 제한으로 외부 모듈을 받지 못해 실패

------
https://chatgpt.com/codex/tasks/task_e_6844333ee1f0832c90b048b540e5116e