### PR TITLE
사용자 이메일 암호화 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ docker logs joosum_dev -f # 개발환경 로그확인
 docker logs server 2>&1 -f | jq # 배포서버 로그확인
 ```
 
+### 환경 변수
+
+사용자 이메일 암호화를 위해 `aes_key` 값을 config.yml에 설정해야 합니다.
+
 ## Version
 
 ---

--- a/backend/pkg/util/encryption.go
+++ b/backend/pkg/util/encryption.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"joosum-backend/pkg/config"
+)
+
+// EncryptString는 AES-GCM을 사용해 문자열을 암호화합니다.
+// 암호화 키는 config.yml의 aes_key 항목을 사용합니다.
+func EncryptString(plain string) (string, error) {
+	key := []byte(config.GetEnvConfig("aes_key"))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	cipherText := aesgcm.Seal(nonce, nonce, []byte(plain), nil)
+	return base64.StdEncoding.EncodeToString(cipherText), nil
+}
+
+// DecryptString은 EncryptString으로 암호화된 값을 복호화합니다.
+func DecryptString(cipherText string) (string, error) {
+	key := []byte(config.GetEnvConfig("aes_key"))
+	data, err := base64.StdEncoding.DecodeString(cipherText)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonceSize := aesgcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("cipher text too short")
+	}
+	nonce, cipherData := data[:nonceSize], data[nonceSize:]
+	plain, err := aesgcm.Open(nil, nonce, cipherData, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}
+
+// DecryptIfPossible은 복호화 실패 시 원본 값을 그대로 반환합니다.
+func DecryptIfPossible(value string) string {
+	plain, err := DecryptString(value)
+	if err != nil {
+		return value
+	}
+	return plain
+}


### PR DESCRIPTION
## 요약
- 이메일 저장 시 AES 암호화를 적용하고 복호화 호환 처리
- 암호화를 위한 `EncryptString` 유틸리티 추가
- 기존 데이터 및 신규 데이터 모두 동작하도록 모델 수정
- README에 `aes_key` 환경 변수 설명 추가

## 테스트
- `go vet ./...` 실행 (네트워크 제한으로 의존성 다운로드 실패)


------
https://chatgpt.com/codex/tasks/task_e_684437009b94832c89b95763e8fc47c2