### PR TITLE
링크 URL 스킴 자동 보정 기능 추가

### DIFF
--- a/backend/app/link/link_usecase.go
+++ b/backend/app/link/link_usecase.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"gopkg.in/errgo.v2/errors"
+	"joosum-backend/pkg/util"
 )
 
 type LinkUsecase struct {
@@ -16,6 +17,9 @@ type LinkUsecase struct {
 }
 
 func (u LinkUsecase) CreateLink(url string, title string, userId string, linkBookId string, thumbnailURL string, tags []string) (*Link, error) {
+
+	// URL 이 http:// 혹은 https:// 로 시작하지 않으면 https:// 를 붙입니다.
+	url = util.EnsureHTTPPrefix(url)
 
 	// linkBookId 가 root 이거나 빈 스트링이라면 기본 폴더에 저장
 	var linkBookName string
@@ -186,6 +190,8 @@ func (u LinkUsecase) UpdateLinkBookIdByLinkId(linkId string, linkBookId string) 
 }
 
 func (u LinkUsecase) UpdateTitleAndUrlByLinkId(linkId string, url string, title string, thumbnailURL string, tags []string) (*Link, error) {
+	// URL 이 http:// 혹은 https:// 로 시작하지 않으면 https:// 를 붙입니다.
+	url = util.EnsureHTTPPrefix(url)
 	link, err := u.linkModel.UpdateTitleAndUrlByLinkId(linkId, url, title, thumbnailURL, tags)
 	if err != nil {
 		return nil, err
@@ -195,6 +201,8 @@ func (u LinkUsecase) UpdateTitleAndUrlByLinkId(linkId string, url string, title 
 }
 
 func (LinkUsecase) GetThumnailURL(url string) (*LinkThumbnailRes, error) {
+	// URL 이 http:// 혹은 https:// 로 시작하지 않으면 https:// 를 붙입니다.
+	url = util.EnsureHTTPPrefix(url)
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/util/url.go
+++ b/backend/pkg/util/url.go
@@ -1,0 +1,14 @@
+package util
+
+import "strings"
+
+// EnsureHTTPPrefix 는 URL 앞에 http:// 혹은 https:// 가 없으면 https:// 를 붙여 반환합니다.
+func EnsureHTTPPrefix(url string) string {
+	if url == "" {
+		return url
+	}
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return url
+	}
+	return "https://" + url
+}


### PR DESCRIPTION
## 요약
- URL 앞에 http/https가 없으면 자동으로 https를 붙이는 util 함수 추가
- 링크 생성, 수정, 썸네일 조회 시 해당 함수를 사용하도록 개선

## 테스트
- `go test ./...` 실행 시 네트워크 제한으로 모듈 다운로드 실패

------
https://chatgpt.com/codex/tasks/task_e_68454b4a173c832c90e0787cadbe7845