### PR TITLE
태그 검색 API 추가

### DIFF
--- a/backend/app/tag/tag_handler.go
+++ b/backend/app/tag/tag_handler.go
@@ -61,9 +61,10 @@ func (h TagHandler) CreateTags(c *gin.Context) {
 // GetTags godoc
 // @Tags 태그
 // @Summary 태그를 조회합니다.
-// @Description 사용자 아이디를 통해 해당 사용자의 모든 태그를 조회합니다.
+// @Description 사용자 아이디를 통해 해당 사용자의 모든 태그를 조회합니다. 검색어를 전달하면 해당 검색어에 맞는 태그만 반환합니다.
 // @Accept  json
 // @Produce  json
+// @Param search query string false "검색어"
 // @Success 200 {array} []string "태그 조회가 성공적으로 이루어졌을 때 태그 배열 반환"
 // @Failure 401 {object} util.APIError "Authorization 헤더가 없을 때 반환합니다."
 // @Failure 500 {object} util.APIError "태그 조회 과정에서 오류가 발생한 경우 반환합니다."
@@ -79,7 +80,18 @@ func (h TagHandler) GetTags(c *gin.Context) {
 
 	userId := currentUser.(*user.User).UserId
 
-	tags, err := h.tagUsecase.FindTagsByUserId(userId)
+	search := c.Query("search")
+
+	var (
+		tags []string
+		err  error
+	)
+
+	if search == "" {
+		tags, err = h.tagUsecase.FindTagsByUserId(userId)
+	} else {
+		tags, err = h.tagUsecase.FindTagsByUserIdAndSearch(userId, search)
+	}
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			c.JSON(http.StatusOK, []string{})

--- a/backend/app/tag/tag_usecase.go
+++ b/backend/app/tag/tag_usecase.go
@@ -44,6 +44,35 @@ func (u TagUsecase) FindTagsByUserId(userId string) ([]string, error) {
 	return tags, nil
 }
 
+// FindTagsByUserIdAndSearch는 사용자 아이디와 검색어로 태그를 조회합니다.
+func (u TagUsecase) FindTagsByUserIdAndSearch(userId string, search string) ([]string, error) {
+	tagData, err := u.tagModel.FindTagByUserId(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make([]string, 0)
+	used := make(map[string]bool)
+
+	for _, tag := range tagData.LastUsed {
+		for _, name := range tagData.Names {
+			if tag == name && util.HangulMatch(tag, search) && !used[tag] {
+				tags = append(tags, tag)
+				used[tag] = true
+			}
+		}
+	}
+
+	for _, name := range tagData.Names {
+		if util.HangulMatch(name, search) && !used[name] {
+			tags = append(tags, name)
+			used[name] = true
+		}
+	}
+
+	return tags, nil
+}
+
 func (u TagUsecase) DeleteTag(userId string, tag string) ([]string, error) {
 	tags, err := u.tagModel.FindTagsByUserId(userId)
 	if err != nil {

--- a/backend/pkg/util/hangul.go
+++ b/backend/pkg/util/hangul.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"strings"
+	"unicode"
+)
+
+// 초성 목록
+var initials = []rune{
+	'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ',
+	'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ',
+}
+
+// GetInitials 는 문자열의 한글 음절을 초성 문자열로 변환합니다.
+func GetInitials(s string) string {
+	var result []rune
+	for _, r := range s {
+		if r >= 0xAC00 && r <= 0xD7A3 {
+			idx := (r - 0xAC00) / 588
+			result = append(result, initials[idx])
+		} else {
+			result = append(result, unicode.ToLower(r))
+		}
+	}
+	return string(result)
+}
+
+// HangulMatch 는 문자열이 검색어와 일치하는지 확인합니다.
+// 검색어가 한글 초성으로만 이루어진 경우 초성 비교를 수행합니다.
+func HangulMatch(target, query string) bool {
+	if query == "" {
+		return true
+	}
+	t := strings.ToLower(target)
+	q := strings.ToLower(query)
+
+	if strings.Contains(t, q) {
+		return true
+	}
+
+	initials := GetInitials(t)
+	if strings.Contains(initials, q) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## 요약
- 태그 조회 API에 검색 기능 추가
- 한글 초성 검색을 위한 헬퍼 함수 추가

## 테스트
- `go test ./...`와 `go vet ./...` 실행 시 의존성 다운로드가 차단되어 실패

------
https://chatgpt.com/codex/tasks/task_e_6857ec724fd0832c99fd4d457febd598