### PR TITLE
오류 응답 구조 개선

### DIFF
--- a/backend/app/auth/auth_handler.go
+++ b/backend/app/auth/auth_handler.go
@@ -34,25 +34,25 @@ type AuthHandler struct {
 func (h AuthHandler) SignUp(c *gin.Context) {
 	var req SignUpReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
 	email, err := h.authUsecase.GetEmailFromJWT(req.Social, req.IdToken)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: fmt.Sprintf("failed to get email from the JWT token: %v", err.Error())})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "이메일을 가져오는 중 오류가 발생했습니다")
 		return
 	}
 
 	isExist, _ := h.userUsecase.GetUserByEmail(email)
 	if isExist != nil {
-		c.JSON(http.StatusConflict, util.APIError{Error: "user already exists"})
+		util.SendError(c, http.StatusConflict, "USER_EXISTS", "이미 존재하는 사용자입니다")
 		return
 	}
 
 	inactiveUser, _ := h.userUsecase.GetInactiveUserByEmail(email)
 	if inactiveUser != nil {
-		c.JSON(http.StatusConflict, util.APIError{Error: "It hasn't been 30 days since you left"})
+		util.SendError(c, http.StatusConflict, "USER_RECENTLY_LEFT", "탈퇴 후 30일이 지나지 않았습니다")
 		return
 	}
 
@@ -71,14 +71,14 @@ func (h AuthHandler) SignUp(c *gin.Context) {
 
 	user, err := h.authUsecase.SignUp(userInfo)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "회원 가입에 실패했습니다")
 		return
 	}
 
 	accessToken, refreshToken, err := h.authUsecase.GenerateNewJWTToken(email)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "토큰 생성 중 오류가 발생했습니다")
 		return
 	}
 
@@ -101,7 +101,7 @@ func (h AuthHandler) Logout(c *gin.Context) {
 	result, err := h.authUsecase.Logout(userId)
 	if err != nil {
 		// 500 Internal Server Error
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -123,7 +123,7 @@ func (h AuthHandler) GetMe(c *gin.Context) {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, util.MsgMissingAuthorization)
 		return
 	}
 
@@ -133,7 +133,7 @@ func (h AuthHandler) GetMe(c *gin.Context) {
 	// 사용자의 링크 수 가져오기
 	linkCount, err := h.linkModel.GetUserLinkCount(userId)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get link count"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "링크 수를 가져오는 데 실패했습니다")
 		return
 	}
 
@@ -141,7 +141,7 @@ func (h AuthHandler) GetMe(c *gin.Context) {
 	req := link.LinkBookListReq{}
 	linkBooks, err := h.linkBookModel.GetLinkBooks(req, userId)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get link books"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "링크북을 가져오는 데 실패했습니다")
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h AuthHandler) GetMe(c *gin.Context) {
 // @Security ApiKeyAuth
 // @Router /protected [get]
 func (h AuthHandler) Protected(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "success"})
+	c.JSON(http.StatusOK, util.APIResponse{Message: "success"})
 }
 
 /*

--- a/backend/app/auth/google_handler.go
+++ b/backend/app/auth/google_handler.go
@@ -37,31 +37,31 @@ type GoogleHandler struct {
 func (h *GoogleHandler) VerifyGoogleAccessToken(c *gin.Context) {
 	var req AccessTokenReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
 	accessToken := req.IdToken
 
 	if accessToken == "" {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "idToken is required"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "idToken 값이 필요합니다")
 		return
 	}
 
 	if valid, err := h.googleUsecae.ValidateIdToken(accessToken); err != nil || !valid {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: "Invalid id token"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유효하지 않은 idToken")
 		return
 	}
 
 	email, err := h.googleUsecae.GetUserEmail(accessToken)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, err.Error())
 		return
 	}
 
 	user, err := h.userUsecase.GetUserByEmail(email)
 	if err != nil && err != mongo.ErrNoDocuments {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("failed to get user by email: %v", err.Error())})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, fmt.Sprintf("failed to get user by email: %v", err.Error()))
 		return
 	}
 
@@ -73,7 +73,7 @@ func (h *GoogleHandler) VerifyGoogleAccessToken(c *gin.Context) {
 	accessToken, refreshToken, err := h.authUsecase.GenerateNewJWTToken(email)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, util.TokenRes{
@@ -96,31 +96,31 @@ func (h *GoogleHandler) VerifyGoogleAccessToken(c *gin.Context) {
 func (h *GoogleHandler) VerifyGoogleAccessTokenInAndroid(c *gin.Context) {
 	var req AccessTokenReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
 	accessToken := req.IdToken
 
 	if accessToken == "" {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "idToken is required"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "idToken 값이 필요합니다")
 		return
 	}
 
 	if valid, err := h.googleUsecae.ValidateIdTokenForAndroid(accessToken); err != nil || !valid {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: "Invalid id token"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유효하지 않은 idToken")
 		return
 	}
 
 	email, err := h.googleUsecae.GetUserEmail(accessToken)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, err.Error())
 		return
 	}
 
 	user, err := h.userUsecase.GetUserByEmail(email)
 	if err != nil && err != mongo.ErrNoDocuments {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("failed to get user by email: %v", err.Error())})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, fmt.Sprintf("failed to get user by email: %v", err.Error()))
 		return
 	}
 
@@ -132,7 +132,7 @@ func (h *GoogleHandler) VerifyGoogleAccessTokenInAndroid(c *gin.Context) {
 	accessToken, refreshToken, err := h.authUsecase.GenerateNewJWTToken(email)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 	c.JSON(http.StatusOK, util.TokenRes{
@@ -144,37 +144,37 @@ func (h *GoogleHandler) VerifyGoogleAccessTokenInAndroid(c *gin.Context) {
 func (h *GoogleHandler) VerifyGoogleAccessTokenInWeb(c *gin.Context) {
 	var req AccessTokenReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
 	accessToken := req.IdToken
 
 	if accessToken == "" {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "idToken is required"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "idToken 값이 필요합니다")
 		return
 	}
 
 	valid, err := h.googleUsecae.ValidateIdTokenForWeb(accessToken)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: fmt.Sprintf("Invalid id token: %v", err)})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, fmt.Sprintf("Invalid id token: %v", err))
 		return
 	}
-	
+
 	if !valid {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: "Invalid id token"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유효하지 않은 idToken")
 		return
 	}
 
 	email, err := h.googleUsecae.GetUserEmail(accessToken)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, err.Error())
 		return
 	}
 
 	user, err := h.userUsecase.GetUserByEmail(email)
 	if err != nil && err != mongo.ErrNoDocuments {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": fmt.Sprintf("failed to get user by email: %v", err.Error())})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, fmt.Sprintf("failed to get user by email: %v", err.Error()))
 		return
 	}
 
@@ -186,7 +186,7 @@ func (h *GoogleHandler) VerifyGoogleAccessTokenInWeb(c *gin.Context) {
 	accessToken, refreshToken, err := h.authUsecase.GenerateNewJWTToken(email)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, util.APIError{Error: err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -225,64 +225,61 @@ func (h *GoogleHandler) AuthGoogleWebCallback(c *gin.Context) {
 	state := c.Query("state")
 	storedState, err := c.Cookie("google_oauth_state")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "state cookie not found"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "state 쿠키를 찾을 수 없습니다")
 		return
 	}
 	if state != storedState {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid oauth state"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "잘못된 OAuth 상태입니다")
 		return
 	}
 
 	// 2) code 가져오기
 	code := c.Query("code")
 	if code == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "code not found"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "코드를 찾을 수 없습니다")
 		return
 	}
 
 	// 3) code로 토큰 교환
 	token, err := googleWebOAuthConfig.Exchange(c, code)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "failed to exchange token: " + err.Error()})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, "토큰 교환 실패: "+err.Error())
 		return
 	}
 
 	// 4) 토큰으로 구글 사용자 정보 가져오기
 	userInfo, err := h.googleUsecae.GetUserInfoFromToken(c, token.AccessToken)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get user info: " + err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유저 정보를 가져오지 못했습니다: "+err.Error())
 		return
 	}
 
 	email := userInfo.Email
 	if email == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "no email in user info"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유저 정보에 이메일이 없습니다")
 		return
 	}
 
 	// 5) DB에서 해당 이메일 유저 조회
 	foundUser, err := h.userUsecase.GetUserByEmail(email)
 	if err != nil && err != mongo.ErrNoDocuments {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch user: " + err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "유저 조회 실패: "+err.Error())
 		return
 	}
 
 	// 5-1) 유저가 없으면 회원가입 로직 (예시로 빈 토큰 리턴)
 	if foundUser == nil {
-		c.JSON(http.StatusOK, gin.H{"message": "user not found, please sign up first"})
+		c.JSON(http.StatusOK, util.APIResponse{Message: "사용자를 찾을 수 없습니다. 먼저 회원가입을 진행해 주세요"})
 		return
 	}
 
 	// 6) JWT 토큰 발급
 	accessTokenStr, refreshTokenStr, err := h.authUsecase.GenerateNewJWTToken(email)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate JWT: " + err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "JWT 생성 실패: "+err.Error())
 		return
 	}
 
 	// 7) 응답 (AccessToken/RefreshToken)
-	c.JSON(http.StatusOK, gin.H{
-		"accessToken":  accessTokenStr,
-		"refreshToken": refreshTokenStr,
-	})
+	c.JSON(http.StatusOK, util.TokenRes{AccessToken: accessTokenStr, RefreshToken: refreshTokenStr})
 }

--- a/backend/app/banner/banner_handler.go
+++ b/backend/app/banner/banner_handler.go
@@ -26,7 +26,7 @@ func (h BannerHandler) CreateBanner(c *gin.Context) {
 
 	var req BannerCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
@@ -34,14 +34,14 @@ func (h BannerHandler) CreateBanner(c *gin.Context) {
 	clickURL := req.ClickURL
 
 	if imageURL == "" || clickURL == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required parameters"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "필수 파라미터가 누락되었습니다")
 		return
 	}
 
 	banner, err := h.BannerUsecase.CreateBanner(imageURL, clickURL)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -62,7 +62,7 @@ func (h BannerHandler) GetBanners(c *gin.Context) {
 	banners, err := h.BannerUsecase.GetBanners()
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -85,14 +85,14 @@ func (h BannerHandler) DeleteBanner(c *gin.Context) {
 	bannerId := c.Param("bannerId")
 
 	if bannerId == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing required parameters"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "필수 파라미터가 누락되었습니다")
 		return
 	}
 
 	count, err := h.BannerUsecase.DeleteBannerById(bannerId)
 
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 

--- a/backend/app/tag/tag_handler.go
+++ b/backend/app/tag/tag_handler.go
@@ -34,7 +34,7 @@ func (h TagHandler) CreateTags(c *gin.Context) {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, util.MsgMissingAuthorization)
 		return
 	}
 
@@ -43,14 +43,14 @@ func (h TagHandler) CreateTags(c *gin.Context) {
 	var req []string
 	if err := c.ShouldBindJSON(&req); err != nil {
 		// 400 Bad Request
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
 	tags, err := h.tagUsecase.CreateTags(userId, req)
 	if err != nil {
 		// 500 Internal Server Error
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -74,7 +74,7 @@ func (h TagHandler) GetTags(c *gin.Context) {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, util.MsgMissingAuthorization)
 		return
 	}
 
@@ -99,7 +99,7 @@ func (h TagHandler) GetTags(c *gin.Context) {
 		}
 
 		// 500 Internal Server Error
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 
@@ -124,7 +124,7 @@ func (h TagHandler) DeleteTag(c *gin.Context) {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, util.MsgMissingAuthorization)
 		return
 	}
 
@@ -135,7 +135,7 @@ func (h TagHandler) DeleteTag(c *gin.Context) {
 	tags, err := h.tagUsecase.DeleteTag(userId, tag)
 	if err != nil {
 		// 500 Internal Server Error
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, err.Error())
 		return
 	}
 

--- a/backend/app/user/user_handler.go
+++ b/backend/app/user/user_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
+	"joosum-backend/pkg/util"
 )
 
 type UserHandler struct {
@@ -36,18 +37,18 @@ func (h UserHandler) DeleteUser(c *gin.Context) {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		util.SendError(c, http.StatusUnauthorized, util.CodeMissingAuthorization, util.MsgMissingAuthorization)
 		return
 	}
 	email := currentUser.(*User).Email
 
 	err := h.userUsecase.UpdateUserToInactiveUserByEmail(email)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "서버에서 유저 삭제 실패"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "서버에서 유저 삭제 실패")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "유저 삭제 성공"})
+	c.JSON(http.StatusOK, util.APIResponse{Message: "유저 삭제 성공"})
 }
 
 // GetWithdrawUsers
@@ -85,7 +86,7 @@ func (h UserHandler) GetWithdrawUsers(c *gin.Context) {
 func (h UserHandler) CheckUserSignupByEmail(c *gin.Context) {
 	email := c.Query("email")
 	if email == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "email is required"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, "이메일 파라미터가 필요합니다")
 		return
 	}
 
@@ -95,7 +96,7 @@ func (h UserHandler) CheckUserSignupByEmail(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"signedUp": false})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check user"})
+		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError, "서버 오류")
 		return
 	}
 

--- a/backend/pkg/util/header.go
+++ b/backend/pkg/util/header.go
@@ -10,7 +10,7 @@ func GetUserId(c *gin.Context) string {
 	currentUser, exists := c.Get("user")
 	if !exists {
 		// 401 Unauthorized
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization header"})
+		SendError(c, http.StatusUnauthorized, CodeMissingAuthorization, MsgMissingAuthorization)
 		return ""
 	}
 

--- a/backend/pkg/util/http_error.go
+++ b/backend/pkg/util/http_error.go
@@ -1,14 +1,39 @@
 package util
 
+import "github.com/gin-gonic/gin"
+
+// APIError 는 API에서 발생하는 오류 응답 형식을 정의합니다.
 type APIError struct {
-	Error string `json:"error"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
+// APIResponse 는 일반적인 메시지 응답 형식을 정의합니다.
 type APIResponse struct {
 	Message string `json:"message"`
 }
 
+// TokenRes 는 액세스 토큰과 리프레시 토큰 쌍을 반환할 때 사용됩니다.
 type TokenRes struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
+}
+
+// 사전 정의된 오류 코드
+const (
+	CodeInvalidRequestBody   = "INVALID_REQUEST_BODY"
+	CodeMissingAuthorization = "MISSING_AUTHORIZATION"
+	CodeInternalServerError  = "INTERNAL_SERVER_ERROR"
+)
+
+// 사전 정의된 오류 메시지(한글)
+const (
+	MsgInvalidRequestBody   = "잘못된 요청 본문입니다."
+	MsgMissingAuthorization = "Authorization 헤더가 없습니다."
+	MsgInternalServerError  = "서버 오류가 발생했습니다."
+)
+
+// SendError 는 오류 응답을 JSON 형태로 클라이언트에 반환합니다.
+func SendError(c *gin.Context, status int, code, message string) {
+	c.JSON(status, APIError{Code: code, Message: message})
 }


### PR DESCRIPTION
## 요약
- API 오류 응답 구조 개선
- 오류 메시지를 한글로 통일
- 일부 핸들러에서 새 오류 응답 함수 사용

## 테스트
- `go vet ./...` 실행 시 네트워크 제한으로 실패
- `gofmt` 적용 완료

------
https://chatgpt.com/codex/tasks/task_e_685e88d16f54832c8721b4d4634e9c97