### PR TITLE
태그 조회 API 기능 개선

### DIFF
--- a/backend/app/tag/tag_handler.go
+++ b/backend/app/tag/tag_handler.go
@@ -65,6 +65,7 @@ func (h TagHandler) CreateTags(c *gin.Context) {
 // @Accept  json
 // @Produce  json
 // @Param search query string false "검색어"
+// @Param sort query string false "정렬 방식" Enums(used,created)
 // @Success 200 {array} []string "태그 조회가 성공적으로 이루어졌을 때 태그 배열 반환"
 // @Failure 401 {object} util.APIError "Authorization 헤더가 없을 때 반환합니다."
 // @Failure 500 {object} util.APIError "태그 조회 과정에서 오류가 발생한 경우 반환합니다."
@@ -81,16 +82,29 @@ func (h TagHandler) GetTags(c *gin.Context) {
 	userId := currentUser.(*user.User).UserId
 
 	search := c.Query("search")
+	sortParam := c.Query("sort")
+
+	if sortParam == "" {
+		sortParam = "used"
+	}
 
 	var (
 		tags []string
 		err  error
 	)
 
-	if search == "" {
-		tags, err = h.tagUsecase.FindTagsByUserId(userId)
+	if sortParam == "created" {
+		if search == "" {
+			tags, err = h.tagUsecase.FindTagsByUserIdCreated(userId)
+		} else {
+			tags, err = h.tagUsecase.FindTagsByUserIdAndSearchCreated(userId, search)
+		}
 	} else {
-		tags, err = h.tagUsecase.FindTagsByUserIdAndSearch(userId, search)
+		if search == "" {
+			tags, err = h.tagUsecase.FindTagsByUserId(userId)
+		} else {
+			tags, err = h.tagUsecase.FindTagsByUserIdAndSearch(userId, search)
+		}
 	}
 	if err != nil {
 		if err == mongo.ErrNoDocuments {

--- a/backend/app/tag/tag_usecase.go
+++ b/backend/app/tag/tag_usecase.go
@@ -44,6 +44,32 @@ func (u TagUsecase) FindTagsByUserId(userId string) ([]string, error) {
 	return tags, nil
 }
 
+// FindTagsByUserIdCreated는 태그 생성 순서대로 태그를 조회합니다.
+func (u TagUsecase) FindTagsByUserIdCreated(userId string) ([]string, error) {
+	tags, err := u.tagModel.FindTagsByUserId(userId)
+	if err != nil {
+		return nil, err
+	}
+	return tags, nil
+}
+
+// FindTagsByUserIdAndSearchCreated는 생성 순서대로 검색어에 맞는 태그를 조회합니다.
+func (u TagUsecase) FindTagsByUserIdAndSearchCreated(userId string, search string) ([]string, error) {
+	tagData, err := u.tagModel.FindTagByUserId(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := make([]string, 0)
+	for _, name := range tagData.Names {
+		if util.HangulMatch(name, search) {
+			tags = append(tags, name)
+		}
+	}
+
+	return tags, nil
+}
+
 // FindTagsByUserIdAndSearch는 사용자 아이디와 검색어로 태그를 조회합니다.
 func (u TagUsecase) FindTagsByUserIdAndSearch(userId string, search string) ([]string, error) {
 	tagData, err := u.tagModel.FindTagByUserId(userId)


### PR DESCRIPTION
## Summary
- `/tags` API에서 `sort=created` 파라미터로 생성 순서 정렬 지원
- TagUsecase에 생성순 조회 로직 추가

## Testing
- `go vet ./...` *(실패 - 네트워크 접근 불가로 모듈 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_685ffe2890f8832c988f5525a5a7e1bc