### PR TITLE
fix(docker): util APIError struct usage

### DIFF
--- a/backend/app/link/linkbook_handler.go
+++ b/backend/app/link/linkbook_handler.go
@@ -26,7 +26,7 @@ type LinkBookHandler struct {
 func (h LinkBookHandler) GetLinkBooks(c *gin.Context) {
 	var req LinkBookListReq
 	if err := c.ShouldBindQuery(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: fmt.Sprintf("Invalid request parameter: %v", err.Error())})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, fmt.Sprintf("잘못된 요청 파라미터: %v", err.Error()))
 		return
 	}
 
@@ -59,7 +59,7 @@ func (h LinkBookHandler) GetLinkBooks(c *gin.Context) {
 func (h LinkBookHandler) CreateLinkBook(c *gin.Context) {
 	var req LinkBookCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 
@@ -108,7 +108,7 @@ func (h LinkBookHandler) CreateLinkBook(c *gin.Context) {
 func (h LinkBookHandler) UpdateLinkBook(c *gin.Context) {
 	var req LinkBookCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, util.APIError{Error: "Invalid request body"})
+		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody, util.MsgInvalidRequestBody)
 		return
 	}
 


### PR DESCRIPTION
## 요약
- LinkBookHandler에서 util.APIError 구조체 변경에 대응
- `ShouldBindQuery`와 `ShouldBindJSON` 오류 처리 시 `util.SendError` 사용

## 테스트
- `go build ./...` 실행 시 외부 모듈 다운로드가 차단되어 실패함

------
https://chatgpt.com/codex/tasks/task_e_6860a3a094c8832cbedf504ccd09a071