### PR TITLE
Fix unused fmt import

### DIFF
--- a/backend/app/auth/auth_handler.go
+++ b/backend/app/auth/auth_handler.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"fmt"
 	"joosum-backend/app/link"
 	"joosum-backend/app/user"
 	"joosum-backend/pkg/util"


### PR DESCRIPTION
## Summary
- 사용하지 않는 fmt 임포트를 삭제하여 빌드 오류 해결

## Testing
- `go build ./...` (실패: 네트워크 차단으로 의존성 다운로드 불가)


------
https://chatgpt.com/codex/tasks/task_e_6860a683ca5c832cb1c87fd88daa5c46