### PR TITLE
배포 스크립트 수정: 기존 컨테이너 삭제

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
         script: |
           docker pull joosum.kr.ncr.ntruss.com/joosum-backend:${{ steps.date.outputs.date }}
           docker stop $(docker ps -q -f 'expose=5001')
+          docker rm $(docker ps -aq -f 'expose=5001') || true
           docker run --rm -d -v /etc/ssl/certs:/etc/ssl/certs -p 5001:5001 \
             --log-opt max-size=10k --log-opt max-file=3 \
             --name server joosum.kr.ncr.ntruss.com/joosum-backend:${{ steps.date.outputs.date }} -env=prod


### PR DESCRIPTION
## 요약
- GitHub Actions 배포 워크플로우에서 기존 컨테이너를 삭제하도록 수정했습니다.

## 테스트 결과
- `go build ./...` 실행 시 네트워크 차단으로 인한 의존성 다운로드 실패
- `go vet ./...` 실행 시 네트워크 차단으로 인한 의존성 다운로드 실패


------
https://chatgpt.com/codex/tasks/task_e_68832501ea10832cbcc156b1cf1a58f4