### PR TITLE
AI 태그 추천 오류 로깅 개선

### DIFF
--- a/backend/app/link/link_handler.go
+++ b/backend/app/link/link_handler.go
@@ -2,10 +2,12 @@ package link
 
 import (
 	"fmt"
+	"log"
+	"net/http"
+
 	"joosum-backend/app/tag"
 	"joosum-backend/app/user"
 	"joosum-backend/pkg/util"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
@@ -51,6 +53,7 @@ type DeleteLinkReq struct {
 func (h LinkHandler) GetAIRecommendedTags(c *gin.Context) {
 	var req AITagRecommendationReq
 	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Printf("[AI 태그 추천] 요청 바인딩 실패: %v", err)
 		util.SendError(c, http.StatusBadRequest, util.CodeInvalidRequestBody)
 		return
 	}
@@ -62,6 +65,7 @@ func (h LinkHandler) GetAIRecommendedTags(c *gin.Context) {
 
 	result, err := h.linkUsecase.GetAIRecommendedTags(req.URL)
 	if err != nil {
+		log.Printf("[AI 태그 추천] URL=%s 처리 중 오류: %v", req.URL, err)
 		c.Error(fmt.Errorf("GetAIRecommendedTags failed: %v", err))
 		util.SendError(c, http.StatusInternalServerError, util.CodeInternalServerError)
 		return


### PR DESCRIPTION
## 요약
- AI 태그 추천 요청 바인딩 및 처리 오류 시 로그를 남겨 원인 파악을 용이하게 했습니다.
- URL 크롤링, HTML 파싱, 본문 추출, OpenAI 호출 과정에서 상세 로그를 추가해 장애 지점을 기록하도록 했습니다.
- OpenAI API 키 누락, 응답 파싱 실패 등 핵심 실패 지점을 콘솔 로그로 남기도록 보완했습니다.

## 테스트
- go test ./... *(docs 모듈이 없어 빌드 단계에서 실패합니다)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ec0f4c96c832c88f3d3b1be7d01e4)